### PR TITLE
API Type Checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+._*
+Desktop.ini
+Thumbs.db
+
+/node_modules

--- a/Form Data.js
+++ b/Form Data.js
@@ -80,7 +80,7 @@ function ModalForm(player) {
             if (data.canceled) return; // ❌ Player closed the form manually
 
             // 🧩 Get all the form values in one array
-            const [textInput, dropdownIndex, amount, confirm] = data.formValues;
+            const [textInput, dropdownIndex, amount, confirm] = /** @type {[string, number, number, boolean]} */ (data.formValues);
 
             // 📣 Send all inputs back to player as a chat message
             player.sendMessage(

--- a/Form Data.js
+++ b/Form Data.js
@@ -62,6 +62,8 @@ world.beforeEvents.chatSend.subscribe((data) => {
 /**
  * 📄 ModalForm: This creates a form with different input types (text, dropdown, slider, toggle)
  * 🎙️ "This is the most powerful form — you can collect multiple types of input at once."
+ * @param {Player} player
+ * @returns {void}
  */
 function ModalForm(player) {
     new ModalFormData() // 🛠️ Start building a modal form
@@ -90,6 +92,8 @@ function ModalForm(player) {
 /**
  * 📨 MessageForm: A simple 2-button confirmation popup
  * 🎙️ "This is perfect for Yes/No or two-choice questions."
+ * @param {Player} player
+ * @returns {void}
  */
 function MessageForm(player) {
     new MessageFormData()
@@ -116,6 +120,8 @@ function MessageForm(player) {
 /**
  * 🧭 ShowMenu: Main action menu with 2 options
  * 🎙️ "This is the main screen players will see — made using ActionFormData, which shows simple buttons."
+ * @param {Player} player
+ * @returns {void}
  */
 function ShowMenu(player) {
     new ActionFormData()
@@ -142,6 +148,8 @@ function ShowMenu(player) {
 /**
  * 🚀 warpMenu: Teleport menu with 3 buttons
  * 🎙️ "This lets players choose where to teleport — a fixed location, random coordinates, or back."
+ * @param {Player} player
+ * @returns {void}
  */
 function warpMenu(player) {
     new ActionFormData()

--- a/engine.d.ts
+++ b/engine.d.ts
@@ -1,0 +1,44 @@
+/// <reference no-default-lib="true"/>
+/// <reference lib="es2020"/>
+
+// Standard library typings for the Minecraft Bedrock scripting runtime.
+// Under the hood, it seems to be implemented with the QuickJS runtime.
+
+// This file is only to enable accurate type checking in your editor,
+// it doesn't need to be bundled with your addon to run.
+
+declare var AggregateError: AggregateErrorConstructor;
+
+interface AggregateError extends Error {}
+
+interface AggregateErrorConstructor extends ErrorConstructor {
+    new (message?: string): AggregateError;
+    (message?: string): AggregateError;
+    readonly prototype: AggregateError;
+}
+
+/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/console) */
+interface Console {
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/error_static) */
+    error(...data: any[]): void;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/info_static) */
+    info(...data: any[]): void;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/log_static) */
+    log(...data: any[]): void;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/console/warn_static) */
+    warn(...data: any[]): void;
+}
+
+declare var console: Console;
+
+declare function __date_clock(): number;
+
+declare var InternalError: InternalErrorConstructor;
+
+interface InternalError extends Error {}
+
+interface InternalErrorConstructor extends ErrorConstructor {
+    new (message?: string): InternalError;
+    (message?: string): InternalError;
+    readonly prototype: InternalError;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "devDependencies": {
         "@minecraft/common": "^1.2.0",
-        "@minecraft/server": "^1.19.0",
-        "@minecraft/server-ui": "^1.3.0",
+        "@minecraft/server": "^2.0.0-beta.1.21.83-stable",
+        "@minecraft/server-ui": "^2.0.0-beta.1.21.83-stable",
         "typescript": "^5.8.3"
       }
     },
@@ -22,9 +22,9 @@
       "license": "MIT"
     },
     "node_modules/@minecraft/server": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.19.0.tgz",
-      "integrity": "sha512-Nq42tLYRcH8AIxpBq1F9/sXia75Vp7k7SXnV+t+yaFNKHwE7LZIfJ3TSbQ4THWTbf1VjwnbSUfJ0qVb3aTDCug==",
+      "version": "2.0.0-beta.1.21.83-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-2.0.0-beta.1.21.83-stable.tgz",
+      "integrity": "sha512-OcxFao4xOL9NJ4IT6yq85ghSHDQr9cpBzFSN/8VMs6GGyI3jErTfc7eHaXP/HudLSWfs+mNeOS2sPiihkB5khw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -35,14 +35,14 @@
       }
     },
     "node_modules/@minecraft/server-ui": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@minecraft/server-ui/-/server-ui-1.3.0.tgz",
-      "integrity": "sha512-Vgo7s+gxjHaNmm8lYTW+HL1JguyZggsn1UB86++eqV1KoRlLnqJH1wBJU2OIb1kQ6HXH0pnL206pxmRy7lmmjg==",
+      "version": "2.0.0-beta.1.21.83-stable",
+      "resolved": "https://registry.npmjs.org/@minecraft/server-ui/-/server-ui-2.0.0-beta.1.21.83-stable.tgz",
+      "integrity": "sha512-M6To9qaOisXA0UA1jRyy3s1HlwGO2IsT5t/KOa8+Wcse4vFL7lv+GWjVVZ7TzTiRX6BqsehTwtYSWFG6EUXiSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@minecraft/common": "^1.0.0",
-        "@minecraft/server": "^1.3.0"
+        "@minecraft/server": "^2.0.0-beta.1.21.83-stable"
       }
     },
     "node_modules/@minecraft/vanilla-data": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,71 @@
+{
+  "name": "form-data",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "form-data",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@minecraft/common": "^1.2.0",
+        "@minecraft/server": "^1.19.0",
+        "@minecraft/server-ui": "^1.3.0",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@minecraft/common": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@minecraft/common/-/common-1.2.0.tgz",
+      "integrity": "sha512-JdmEq4P3Z/FtoBzhLijFgMSVFnFRrUoLwY8DHHrgtFo0mfLTOLTB1RErYjLMsA6b7BGVNxkX/pfFRiH7QZ0XwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@minecraft/server": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-1.19.0.tgz",
+      "integrity": "sha512-Nq42tLYRcH8AIxpBq1F9/sXia75Vp7k7SXnV+t+yaFNKHwE7LZIfJ3TSbQ4THWTbf1VjwnbSUfJ0qVb3aTDCug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@minecraft/common": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@minecraft/vanilla-data": ">=1.20.70"
+      }
+    },
+    "node_modules/@minecraft/server-ui": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@minecraft/server-ui/-/server-ui-1.3.0.tgz",
+      "integrity": "sha512-Vgo7s+gxjHaNmm8lYTW+HL1JguyZggsn1UB86++eqV1KoRlLnqJH1wBJU2OIb1kQ6HXH0pnL206pxmRy7lmmjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@minecraft/common": "^1.0.0",
+        "@minecraft/server": "^1.3.0"
+      }
+    },
+    "node_modules/@minecraft/vanilla-data": {
+      "version": "1.21.81",
+      "resolved": "https://registry.npmjs.org/@minecraft/vanilla-data/-/vanilla-data-1.21.81.tgz",
+      "integrity": "sha512-YODTWnkEiFc9VjKOGOuLXZZQpkLQw9EIsxAoHtBT+K8huDv5nWLheX5hc1Z9OqY/+iFaIT7ueJNfBbXW/WOF1A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "form-data",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@minecraft/common": "^1.2.0",
+    "@minecraft/server": "^1.19.0",
+    "@minecraft/server-ui": "^1.3.0",
+    "typescript": "^5.8.3"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "devDependencies": {
     "@minecraft/common": "^1.2.0",
-    "@minecraft/server": "^1.19.0",
-    "@minecraft/server-ui": "^1.3.0",
+    "@minecraft/server": "^2.0.0-beta.1.21.83-stable",
+    "@minecraft/server-ui": "^2.0.0-beta.1.21.83-stable",
     "typescript": "^5.8.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "module": "ES2020",
+    "moduleResolution": "Node10",
+    "target": "ES2020",
+    "isolatedModules": true,
+    "lib": [],
+    "noEmit": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "allowUnreachableCode": false,
+    "noUnusedLocals": true,
+    "allowUnusedLabels": false,
+    "noUnusedParameters": true
+  }
+}


### PR DESCRIPTION
This adds editor-supported type checking which validates how the code is written, corresponding to the types from the APIs on npm. This makes it easier to write scripts around the APIs because they will autocomplete in your editor when using them, and it will also announce to you when it isn't being used quite as expected. Super awesome!

Note that this is still JavaScript, yet it can behave like TypeScript. So functionally this is usable just like TypeScript, but you don't need to compile your code to enable this type checking. It simply shows in your editor instead, no custom syntax needed.

The changes in this commit are carried over from a project that I started working on a few months ago, which looks into similar experimentation.

https://github.com/Offroaders123/Bedrock-Script-API/tree/dba201420db2a8c30987a4e7069721fcf1350afc